### PR TITLE
various cleanups

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,15 +6,15 @@ mkdir -p test/bin
 
 
 # Build Examples.
-${CXX:=clang++} -std=c++11 -I. ./examples/json_example.cpp -o ./examples/bin/json_example
-${CXX} -std=c++11 -I. ./examples/array_example.cpp -o ./examples/bin/array_example
-${CXX} -std=c++11 -I. ./examples/prim_example.cpp -o ./examples/bin/prim_example
-${CXX} -std=c++11 -I. ./examples/init_example.cpp -o ./examples/bin/init_example
-${CXX} -std=c++11 -I. ./examples/load_example.cpp -o ./examples/bin/load_example
-${CXX} -std=c++11 -I. ./examples/iter_example.cpp -o ./examples/bin/iter_example
+${CXX:=clang++} -Wall -Wextra -pedantic -std=c++11 -I. ./examples/json_example.cpp -o ./examples/bin/json_example
+${CXX}  -Wall -Wextra -pedantic -std=c++11 -I. ./examples/array_example.cpp -o ./examples/bin/array_example
+${CXX}  -Wall -Wextra -pedantic -std=c++11 -I. ./examples/prim_example.cpp -o ./examples/bin/prim_example
+${CXX}  -Wall -Wextra -pedantic -std=c++11 -I. ./examples/init_example.cpp -o ./examples/bin/init_example
+${CXX}  -Wall -Wextra -pedantic -std=c++11 -I. ./examples/load_example.cpp -o ./examples/bin/load_example
+${CXX}  -Wall -Wextra -pedantic -std=c++11 -I. ./examples/iter_example.cpp -o ./examples/bin/iter_example
 
 # Build Test Tool
-${CXX} -std=c++11 -I. ./test/tester.cpp -o ./test/bin/tester
+${CXX}  -Wall -Wextra -pedantic -std=c++11 -I. ./test/tester.cpp -o ./test/bin/tester
 
 echo "Done. See './examples' for examples, and './examples/bin' for the executables."
 echo "To run tests, run cd test; python ./run.py"

--- a/build.sh
+++ b/build.sh
@@ -3,16 +3,18 @@
 mkdir -p examples/bin
 mkdir -p test/bin
 
+
+
 # Build Examples.
-clang++ -std=c++11 -I. ./examples/json_example.cpp -o ./examples/bin/json_example
-clang++ -std=c++11 -I. ./examples/array_example.cpp -o ./examples/bin/array_example
-clang++ -std=c++11 -I. ./examples/prim_example.cpp -o ./examples/bin/prim_example
-clang++ -std=c++11 -I. ./examples/init_example.cpp -o ./examples/bin/init_example
-clang++ -std=c++11 -I. ./examples/load_example.cpp -o ./examples/bin/load_example
-clang++ -std=c++11 -I. ./examples/iter_example.cpp -o ./examples/bin/iter_example
+${CXX:=clang++} -std=c++11 -I. ./examples/json_example.cpp -o ./examples/bin/json_example
+${CXX} -std=c++11 -I. ./examples/array_example.cpp -o ./examples/bin/array_example
+${CXX} -std=c++11 -I. ./examples/prim_example.cpp -o ./examples/bin/prim_example
+${CXX} -std=c++11 -I. ./examples/init_example.cpp -o ./examples/bin/init_example
+${CXX} -std=c++11 -I. ./examples/load_example.cpp -o ./examples/bin/load_example
+${CXX} -std=c++11 -I. ./examples/iter_example.cpp -o ./examples/bin/iter_example
 
 # Build Test Tool
-clang++ -std=c++11 -I. ./test/tester.cpp -o ./test/bin/tester
+${CXX} -std=c++11 -I. ./test/tester.cpp -o ./test/bin/tester
 
 echo "Done. See './examples' for examples, and './examples/bin' for the executables."
 echo "To run tests, run cd test; python ./run.py"

--- a/json.hpp
+++ b/json.hpp
@@ -148,6 +148,8 @@ class JSON
         }
 
         JSON& operator=( const JSON &other ) {
+            if (&other == this) return *this;
+
             switch( other.Type ) {
             case Class::Object:
                 Internal.Map = 

--- a/json.hpp
+++ b/json.hpp
@@ -38,7 +38,7 @@ namespace {
                 case '\t': output += "\\t";  break;
                 default  : output += str[i]; break;
             }
-        return std::move( output );
+        return output;
     }
 }
 
@@ -283,7 +283,7 @@ class JSON
         /// Functions for getting primitives from the JSON object.
         bool IsNull() const { return Type == Class::Null; }
 
-        string ToString() const { bool b; return std::move( ToString( b ) ); }
+        string ToString() const { bool b; return ToString( b ); }
         string ToString( bool &ok ) const {
             ok = (Type == Class::String);
             return ok ? std::move( json_escape( *Internal.String ) ): string("");
@@ -408,18 +408,18 @@ class JSON
 };
 
 JSON Array() {
-    return std::move( JSON::Make( JSON::Class::Array ) );
+    return JSON::Make( JSON::Class::Array );
 }
 
 template <typename... T>
 JSON Array( T... args ) {
     JSON arr = JSON::Make( JSON::Class::Array );
     arr.append( args... );
-    return std::move( arr );
+    return arr;
 }
 
 JSON Object() {
-    return std::move( JSON::Make( JSON::Class::Object ) );
+    return JSON::Make( JSON::Class::Object );
 }
 
 std::ostream& operator<<( std::ostream &os, const JSON &json ) {
@@ -440,7 +440,7 @@ namespace {
         ++offset;
         consume_ws( str, offset );
         if( str[offset] == '}' ) {
-            ++offset; return std::move( Object );
+            ++offset; return Object;
         }
 
         while( true ) {
@@ -467,7 +467,7 @@ namespace {
             }
         }
 
-        return std::move( Object );
+        return Object;
     }
 
     JSON parse_array( const string &str, size_t &offset ) {
@@ -477,7 +477,7 @@ namespace {
         ++offset;
         consume_ws( str, offset );
         if( str[offset] == ']' ) {
-            ++offset; return std::move( Array );
+            ++offset; return Array;
         }
 
         while( true ) {
@@ -492,11 +492,11 @@ namespace {
             }
             else {
                 std::cerr << "ERROR: Array: Expected ',' or ']', found '" << str[offset] << "'\n";
-                return std::move( JSON::Make( JSON::Class::Array ) );
+                return JSON::Make( JSON::Class::Array );
             }
         }
 
-        return std::move( Array );
+        return Array;
     }
 
     JSON parse_string( const string &str, size_t &offset ) {
@@ -521,7 +521,7 @@ namespace {
                             val += c;
                         else {
                             std::cerr << "ERROR: String: Expected hex character in unicode escape, found '" << c << "'\n";
-                            return std::move( JSON::Make( JSON::Class::String ) );
+                            return JSON::Make( JSON::Class::String );
                         }
                     }
                     offset += 4;
@@ -534,7 +534,7 @@ namespace {
         }
         ++offset;
         String = val;
-        return std::move( String );
+        return String;
     }
 
     JSON parse_number( const string &str, size_t &offset ) {
@@ -563,7 +563,7 @@ namespace {
                     exp_str += c;
                 else if( !isspace( c ) && c != ',' && c != ']' && c != '}' ) {
                     std::cerr << "ERROR: Number: Expected a number for exponent, found '" << c << "'\n";
-                    return std::move( JSON::Make( JSON::Class::Null ) );
+                    return JSON::Make( JSON::Class::Null );
                 }
                 else
                     break;
@@ -572,7 +572,7 @@ namespace {
         }
         else if( !isspace( c ) && c != ',' && c != ']' && c != '}' ) {
             std::cerr << "ERROR: Number: unexpected character '" << c << "'\n";
-            return std::move( JSON::Make( JSON::Class::Null ) );
+            return JSON::Make( JSON::Class::Null );
         }
         --offset;
         
@@ -584,7 +584,7 @@ namespace {
             else
                 Number = std::stol( val );
         }
-        return std::move( Number );
+        return Number;
     }
 
     JSON parse_bool( const string &str, size_t &offset ) {
@@ -595,20 +595,20 @@ namespace {
             Bool = false;
         else {
             std::cerr << "ERROR: Bool: Expected 'true' or 'false', found '" << str.substr( offset, 5 ) << "'\n";
-            return std::move( JSON::Make( JSON::Class::Null ) );
+            return JSON::Make( JSON::Class::Null );
         }
         offset += (Bool.ToBool() ? 4 : 5);
-        return std::move( Bool );
+        return Bool;
     }
 
     JSON parse_null( const string &str, size_t &offset ) {
         JSON Null;
         if( str.substr( offset, 4 ) != "null" ) {
             std::cerr << "ERROR: Null: Expected 'null', found '" << str.substr( offset, 4 ) << "'\n";
-            return std::move( JSON::Make( JSON::Class::Null ) );
+            return JSON::Make( JSON::Class::Null );
         }
         offset += 4;
-        return std::move( Null );
+        return Null;
     }
 
     JSON parse_next( const string &str, size_t &offset ) {
@@ -616,14 +616,14 @@ namespace {
         consume_ws( str, offset );
         value = str[offset];
         switch( value ) {
-            case '[' : return std::move( parse_array( str, offset ) );
-            case '{' : return std::move( parse_object( str, offset ) );
-            case '\"': return std::move( parse_string( str, offset ) );
+            case '[' : return parse_array( str, offset );
+            case '{' : return parse_object( str, offset );
+            case '\"': return parse_string( str, offset );
             case 't' :
-            case 'f' : return std::move( parse_bool( str, offset ) );
-            case 'n' : return std::move( parse_null( str, offset ) );
+            case 'f' : return parse_bool( str, offset );
+            case 'n' : return parse_null( str, offset );
             default  : if( ( value <= '9' && value >= '0' ) || value == '-' )
-                           return std::move( parse_number( str, offset ) );
+                           return parse_number( str, offset );
         }
         std::cerr << "ERROR: Parse: Unknown starting character '" << value << "'\n";
         return JSON();
@@ -632,7 +632,7 @@ namespace {
 
 JSON JSON::Load( const string &str ) {
     size_t offset = 0;
-    return std::move( parse_next( str, offset ) );
+    return parse_next( str, offset );
 }
 
 } // End Namespace json

--- a/json.hpp
+++ b/json.hpp
@@ -265,7 +265,7 @@ class JSON
 
         int length() const {
             if( Type == Class::Array )
-                return Internal.List->size();
+                return static_cast<int>(Internal.List->size());
             else
                 return -1;
         }
@@ -278,9 +278,9 @@ class JSON
 
         int size() const {
             if( Type == Class::Object )
-                return Internal.Map->size();
+                return static_cast<int>(Internal.Map->size());
             else if( Type == Class::Array )
-                return Internal.List->size();
+                return static_cast<int>(Internal.List->size());
             else
                 return -1;
         }

--- a/json.hpp
+++ b/json.hpp
@@ -379,7 +379,6 @@ class JSON
                 default:
                     return "";
             }
-            return "";
         }
 
         friend std::ostream& operator<<( std::ostream&, const JSON & );
@@ -450,7 +449,7 @@ namespace {
             ++offset; return Object;
         }
 
-        while( true ) {
+        for (;;) {
             JSON Key = parse_next( str, offset );
             consume_ws( str, offset );
             if( str[offset] != ':' ) {
@@ -487,7 +486,7 @@ namespace {
             ++offset; return Array;
         }
 
-        while( true ) {
+        for (;;) {
             Array[index++] = parse_next( str, offset );
             consume_ws( str, offset );
 
@@ -548,7 +547,7 @@ namespace {
         char c;
         bool isDouble = false;
         long exp = 0;
-        while( true ) {
+        for (;;) {
             c = str[offset++];
             if( (c == '-') || (c >= '0' && c <= '9') )
                 val += c;
@@ -562,7 +561,7 @@ namespace {
         if( c == 'E' || c == 'e' ) {
             c = str[ offset++ ];
             if( c == '-' ){ ++offset; exp_str += '-';}
-            while( true ) {
+            for (;;) {
                 c = str[ offset++ ];
                 if( c >= '0' && c <= '9' )
                     exp_str += c;

--- a/json.hpp
+++ b/json.hpp
@@ -98,6 +98,12 @@ class JSON
 
         JSON() : Internal(), Type( Class::Null ){}
 
+        explicit JSON(Class type)
+            : JSON()
+        {
+            SetType( type );
+        }
+
         JSON( initializer_list<JSON> list ) 
             : JSON() 
         {
@@ -194,8 +200,7 @@ class JSON
         JSON( std::nullptr_t ) : Internal(), Type( Class::Null ){}
 
         static JSON Make( Class type ) {
-            JSON ret; ret.SetType( type );
-            return ret;
+            return JSON(type);
         }
 
         static JSON Load( const string & );
@@ -333,13 +338,13 @@ class JSON
         }
 
         string dump( int depth = 1, string tab = "  ") const {
-            string pad = "";
-            for( int i = 0; i < depth; ++i, pad += tab );
-
             switch( Type ) {
                 case Class::Null:
                     return "null";
                 case Class::Object: {
+                    string pad = "";
+                    for( int i = 0; i < depth; ++i, pad += tab );
+
                     string s = "{\n";
                     bool skip = true;
                     for( auto &p : *Internal.Map ) {
@@ -453,7 +458,7 @@ namespace {
             consume_ws( str, ++offset );
             JSON Value = parse_next( str, offset );
             Object[Key.ToString()] = Value;
-            
+
             consume_ws( str, offset );
             if( str[offset] == ',' ) {
                 ++offset; continue;
@@ -473,7 +478,7 @@ namespace {
     JSON parse_array( const string &str, size_t &offset ) {
         JSON Array = JSON::Make( JSON::Class::Array );
         unsigned index = 0;
-        
+
         ++offset;
         consume_ws( str, offset );
         if( str[offset] == ']' ) {
@@ -500,7 +505,6 @@ namespace {
     }
 
     JSON parse_string( const string &str, size_t &offset ) {
-        JSON String;
         string val;
         for( char c = str[++offset]; c != '\"' ; c = str[++offset] ) {
             if( c == '\\' ) {
@@ -533,8 +537,7 @@ namespace {
                 val += c;
         }
         ++offset;
-        String = val;
-        return String;
+        return JSON(val);
     }
 
     JSON parse_number( const string &str, size_t &offset ) {
@@ -575,7 +578,7 @@ namespace {
             return JSON::Make( JSON::Class::Null );
         }
         --offset;
-        
+
         if( isDouble )
             Number = std::stod( val ) * std::pow( 10, exp );
         else {
@@ -602,13 +605,12 @@ namespace {
     }
 
     JSON parse_null( const string &str, size_t &offset ) {
-        JSON Null;
         if( str.substr( offset, 4 ) != "null" ) {
             std::cerr << "ERROR: Null: Expected 'null', found '" << str.substr( offset, 4 ) << "'\n";
             return JSON::Make( JSON::Class::Null );
         }
         offset += 4;
-        return Null;
+        return JSON();
     }
 
     JSON parse_next( const string &str, size_t &offset ) {

--- a/json.hpp
+++ b/json.hpp
@@ -372,7 +372,6 @@ class JSON
                 default:
                     return "";
             }
-            return "";
         }
 
         friend std::ostream& operator<<( std::ostream&, const JSON & );
@@ -443,7 +442,7 @@ namespace {
             ++offset; return std::move( Object );
         }
 
-        while( true ) {
+        for (;;) {
             JSON Key = parse_next( str, offset );
             consume_ws( str, offset );
             if( str[offset] != ':' ) {
@@ -480,7 +479,7 @@ namespace {
             ++offset; return std::move( Array );
         }
 
-        while( true ) {
+        for (;;) {
             Array[index++] = parse_next( str, offset );
             consume_ws( str, offset );
 
@@ -543,7 +542,7 @@ namespace {
         char c;
         bool isDouble = false;
         long exp = 0;
-        while( true ) {
+        for (;;) {
             c = str[offset++];
             if( (c == '-') || (c >= '0' && c <= '9') )
                 val += c;
@@ -557,7 +556,7 @@ namespace {
         if( c == 'E' || c == 'e' ) {
             c = str[ offset++ ];
             if( c == '-' ){ ++offset; exp_str += '-';}
-            while( true ) {
+            for (;;) {
                 c = str[ offset++ ];
                 if( c >= '0' && c <= '9' )
                     exp_str += c;


### PR DESCRIPTION
Various cleanups for efficiency, including removing use of std::move, see notes. The use of std::move you had was actually causing the code to be potentially slower and was at the very least unnecessary.
