### PR TITLE
Fixing missing inline from non-template functions

### DIFF
--- a/json.hpp
+++ b/json.hpp
@@ -418,7 +418,7 @@ class JSON
         Class Type = Class::Null;
 };
 
-JSON Array() {
+inline JSON Array() {
     return std::move( JSON::Make( JSON::Class::Array ) );
 }
 
@@ -429,11 +429,11 @@ JSON Array( T... args ) {
     return std::move( arr );
 }
 
-JSON Object() {
+inline JSON Object() {
     return std::move( JSON::Make( JSON::Class::Object ) );
 }
 
-std::ostream& operator<<( std::ostream &os, const JSON &json ) {
+inline std::ostream& operator<<( std::ostream &os, const JSON &json ) {
     os << json.dump();
     return os;
 }
@@ -641,7 +641,7 @@ namespace {
     }
 }
 
-JSON JSON::Load( const string &str ) {
+inline JSON JSON::Load( const string &str ) {
     size_t offset = 0;
     return std::move( parse_next( str, offset ) );
 }


### PR DESCRIPTION
As issue #4 points out, json.hpp can not be included from multiple files. Adding `inline` in front of non-template functions fix this issue without having to introduce a separate .cpp file.